### PR TITLE
Fix route syntax in documentation

### DIFF
--- a/getting_started/walkthrough_-_node_and_ghost/walkthrough_ii.md
+++ b/getting_started/walkthrough_-_node_and_ghost/walkthrough_ii.md
@@ -157,15 +157,15 @@ However, with the help of port mapping, we can run multiple instances of the Gho
 
 ```
 # Create a container that maps port 8080 on the host to port 2368 on the container.
-C:\> turbo run -d --route-add=8080:2368 ghost:0.5.1
+C:\> turbo run -d --route-add=tcp://2368:8080 ghost:0.5.1
 8bc1c8a0774e452391d6be6255d9d13e
 
-# Create a container that maps port 8081 on the host to port 2368 on the container.
-C:\> turbo run -d --route-add=8081:2368 ghost:0.5.1
+# Create a container that maps port 2368 on the host to port 8081 on the container.
+C:\> turbo run -d --route-add=tcp://2368:8081 ghost:0.5.1
 8a524a9fd6a047778bc88f3169a90780
 
 # Create a container that maps port 8082 on the host to port 2368 on the container.
-C:\> turbo run -d --route-add=8082:2368 ghost:0.5.1
+C:\> turbo run -d --route-add=tcp://2368:8082 ghost:0.5.1
 cee869387b74474b89bafccb5b590884
 ```
 
@@ -265,11 +265,11 @@ Imagine that you have a live environment with a production, testing, and develop
 
 ```
 # Create a Ghost 0.5.0 instance using the same database and config on port 9090
-C:\> turbo run -d --route-add=9090:2368 ghost:0.5.0,ghost-db,ghost-config
+C:\> turbo run -d --route-add=tcp://2368:9090 ghost:0.5.0,ghost-db,ghost-config
 
 # Create a Ghost 0.5.1 instance using the same database and config on port 9091
-C:\> turbo run -d --route-add=9091:2368 ghost:0.5.1,ghost-db,ghost-config
+C:\> turbo run -d --route-add=tcp://2368:9091 ghost:0.5.1,ghost-db,ghost-config
 
 # Create a Ghost 0.5.2 instance using the same database and config on port 9092
-C:\> turbo run -d --route-add=9092:2368 ghost:0.5.2,ghost-db,ghost-config
+C:\> turbo run -d --route-add=tcp://2368:9092 ghost:0.5.2,ghost-db,ghost-config
 ```

--- a/reference/command_line/commit.md
+++ b/reference/command_line/commit.md
@@ -17,8 +17,8 @@ Usage: commit <options> [<container>] [<image>]
       --hosts=VALUE          Add an entry to the virtual /etc/hosts file (<redirect>:<name>)
       --no-base              Do not merge the base image into the new image
       --overwrite            Overwrite existing image
-      --route-add=VALUE       Add route mapping. Supported protocols: ip, pipe, tcp, udp
-      --route-block=VALUE     Block specified route or protocol. Supported protocols: ip, tcp, udp
+      --route-add=VALUE      Add route mapping. Supported protocols: ip, pipe, tcp, udp
+      --route-block=VALUE    Block specified route or protocol. Supported protocols: ip, tcp, udp
       --startup-file=VALUE   Override the default startup file and save it to the committed image
       --trigger=VALUE        Execute named group of startup files
       --wait-after-error     Leave program open after error

--- a/reference/command_line/commit.md
+++ b/reference/command_line/commit.md
@@ -17,8 +17,8 @@ Usage: commit <options> [<container>] [<image>]
       --hosts=VALUE          Add an entry to the virtual /etc/hosts file (<redirect>:<name>)
       --no-base              Do not merge the base image into the new image
       --overwrite            Overwrite existing image
-      --route-add=VALUE      Add a TCP or UDP mapping. Format: [<hostPort>]:<containerPort>[/tcp|udp]
-      --route-block=VALUE    Isolate all ports of specified protocol (TCP or UDP) by default
+      --route-add=VALUE       Add route mapping. Supported protocols: ip, pipe, tcp, udp
+      --route-block=VALUE     Block specified route or protocol. Supported protocols: ip, tcp, udp
       --startup-file=VALUE   Override the default startup file and save it to the committed image
       --trigger=VALUE        Execute named group of startup files
       --wait-after-error     Leave program open after error

--- a/reference/command_line/continue.md
+++ b/reference/command_line/continue.md
@@ -29,10 +29,8 @@ Usage: turbo continue <options> <state-id>
                                only to me
       --public               Synchronize this container publicly, visible to
                                everyone
-      --route-add=VALUE      Add a TCP or UDP mapping
-                               format: [<hostPort>]:<containerPort>[/tcp|udp]
-      --route-block=VALUE    Isolate all ports of specified protocol (TCP or
-                               UDP) by default
+      --route-add=VALUE            Add route mapping. Supported protocols: ip, pipe, tcp, udp
+      --route-block=VALUE          Block specified route or protocol. Supported protocols: ip, tcp, udp
       --startup-file=VALUE   Override the default startup file
       --startup-verb=VALUE   Override the default startup verb
       --trigger=VALUE        Execute named group of startup files

--- a/reference/command_line/continue.md
+++ b/reference/command_line/continue.md
@@ -29,8 +29,8 @@ Usage: turbo continue <options> <state-id>
                                only to me
       --public               Synchronize this container publicly, visible to
                                everyone
-      --route-add=VALUE            Add route mapping. Supported protocols: ip, pipe, tcp, udp
-      --route-block=VALUE          Block specified route or protocol. Supported protocols: ip, tcp, udp
+      --route-add=VALUE      Add route mapping. Supported protocols: ip, pipe, tcp, udp
+      --route-block=VALUE    Block specified route or protocol. Supported protocols: ip, tcp, udp
       --startup-file=VALUE   Override the default startup file
       --startup-verb=VALUE   Override the default startup verb
       --trigger=VALUE        Execute named group of startup files

--- a/reference/command_line/netstat.md
+++ b/reference/command_line/netstat.md
@@ -12,7 +12,7 @@ Usage: turbo netstat <container>
 #### Examples:
 
 ```
-> turbo run --route-add=:80 --route-add=:8081 --hosts=localhost:lhost --link=0218:service -d <image> 63621076457c4b4fb7fff3fcbfda06b1
+> turbo run --route-add=tcp://8080:80 --hosts=localhost:lhost --link=0218:service -d <image> 63621076457c4b4fb7fff3fcbfda06b1
 > turbo netstat 6362
 
 Active port mappings:

--- a/reference/command_line/new.md
+++ b/reference/command_line/new.md
@@ -36,8 +36,8 @@ Usage: new <options> [<image>] [--name=<name>]
       --private              Synchronize this container privately, visible only to me
       --public               Synchronize this container publicly, visible to everyone
       --pull                 Pulls base images from hub before running, if they exist
-      --route-add=VALUE            Add route mapping. Supported protocols: ip, pipe, tcp, udp
-      --route-block=VALUE          Block specified route or protocol. Supported protocols: ip, tcp, udp
+      --route-add=VALUE      Add route mapping. Supported protocols: ip, pipe, tcp, udp
+      --route-block=VALUE    Block specified route or protocol. Supported protocols: ip, tcp, udp
       --startup-file=VALUE   Override the default startup file
       --startup-file-default=VALUE
                              Overrides the default startup file if the main image does not have one

--- a/reference/command_line/new.md
+++ b/reference/command_line/new.md
@@ -36,8 +36,8 @@ Usage: new <options> [<image>] [--name=<name>]
       --private              Synchronize this container privately, visible only to me
       --public               Synchronize this container publicly, visible to everyone
       --pull                 Pulls base images from hub before running, if they exist
-      --route-add=VALUE      Add a TCP or UDP mapping. Format: [<hostPort>]:<containerPort>[/tcp|udp]
-      --route-block=VALUE    Isolate all ports of specified protocol (TCP or UDP) by default
+      --route-add=VALUE            Add route mapping. Supported protocols: ip, pipe, tcp, udp
+      --route-block=VALUE          Block specified route or protocol. Supported protocols: ip, tcp, udp
       --startup-file=VALUE   Override the default startup file
       --startup-file-default=VALUE
                              Overrides the default startup file if the main image does not have one
@@ -204,14 +204,11 @@ All network operations (opening/closing ports, for example) are passed through t
 
 ```
 # Map container tcp port 8080 to local port 80
-> turbo new --route-add=80:8080 <image>
+> turbo new --route-add=tcp://8080:90 <image>
 
 # Map udp traffic on container port 8080 to local port 80
-> turbo new --route-add=80:8080/udp <image>
+> turbo new --route-add=udp://8080:90 <image>
 
-# Map container tcp port 80 to random port on local machine
-# The random port can be later queried using the netstat command
-> turbo new --route-add=:80 <image>
 ```
 
 The default policy of allowing containers to bind to any port on the local machine can be changed with the `--route-block` flag. It isolates all services bound to container ports on specified protocols (tcp or udp). They can only be opened using the `--route-add` flag.
@@ -222,7 +219,7 @@ The default policy of allowing containers to bind to any port on the local machi
 
 # Isolate all tcp and udp services, but allow container tcp port 3486
 # be bound to port 80 on local machine
-> turbo new --route-block=tcp,udp --route-add=80:3486 <image>
+> turbo new --route-block=tcp,udp --route-add=tcp://3486:80 <image>
 ```
 
 #### Adding Custom Name Resolution Entries

--- a/reference/command_line/run.md
+++ b/reference/command_line/run.md
@@ -34,8 +34,8 @@ Usage: run <options> [<image>][+skin(color)] [<parameters>...]
       --private              Synchronize this container privately, visible only to me
       --public               Synchronize this container publicly, visible to everyone
       --pull                 Pulls base images from hub before running, if they exist
-      --route-add=VALUE            Add route mapping. Supported protocols: ip, pipe, tcp, udp
-      --route-block=VALUE          Block specified route or protocol. Supported protocols: ip, tcp, udp
+      --route-add=VALUE      Add route mapping. Supported protocols: ip, pipe, tcp, udp
+      --route-block=VALUE    Block specified route or protocol. Supported protocols: ip, tcp, udp
       --startup-file=VALUE   Override the default startup file
       --startup-file-default=VALUE
                              Overrides the default startup file if the main image does not have one

--- a/reference/command_line/run.md
+++ b/reference/command_line/run.md
@@ -34,8 +34,8 @@ Usage: run <options> [<image>][+skin(color)] [<parameters>...]
       --private              Synchronize this container privately, visible only to me
       --public               Synchronize this container publicly, visible to everyone
       --pull                 Pulls base images from hub before running, if they exist
-      --route-add=VALUE      Add a TCP or UDP mapping. Format: [<hostPort>]:<containerPort>[/tcp|udp]
-      --route-block=VALUE    Isolate all ports of specified protocol (TCP or UDP) by default
+      --route-add=VALUE            Add route mapping. Supported protocols: ip, pipe, tcp, udp
+      --route-block=VALUE          Block specified route or protocol. Supported protocols: ip, tcp, udp
       --startup-file=VALUE   Override the default startup file
       --startup-file-default=VALUE
                              Overrides the default startup file if the main image does not have one
@@ -202,14 +202,11 @@ All network operations (opening/closing ports, for example) are passed through t
 
 ```
 # Map container tcp port 8080 to local port 80
-> turbo run --route-add=80:8080 <image>
+> turbo run --route-add=tcp://8080:80 <image>
 
 # Map udp traffic on container port 8080 to local port 80
-> turbo run --route-add=80:8080/udp <image>
+> turbo run --route-add=udp://8080:80 <image>
 
-# Map container tcp port 80 to random port on local machine
-# The random port can be later queried using the netstat command
-> turbo run --route-add=:80 <image>
 ```
 
 The default policy of allowing containers to bind to any port on the local machine can be changed with the `--route-block` flag. It isolates all services bound to container ports on specified protocols (tcp or udp). They can only be opened using the `--route-add` flag.
@@ -220,7 +217,7 @@ The default policy of allowing containers to bind to any port on the local machi
 
 # Isolate all tcp and udp services, but allow container tcp port 3486
 # be bound to port 80 on local machine
-> turbo run --route-block=tcp,udp --route-add=80:3486 <image>
+> turbo run --route-block=tcp,udp --route-add=tcp://3486:80 <image>
 ```
 
 #### Adding Custom Name Resolution Entries

--- a/reference/command_line/start.md
+++ b/reference/command_line/start.md
@@ -32,8 +32,8 @@ Usage: start <options> <container>
       --private              Synchronize this container privately, visible only to me
       --public               Synchronize this container publicly, visible to everyone
       --pull                 Pulls base images from hub before running, if they exist
-      --route-add=VALUE      Add a TCP or UDP mapping. Format: [<hostPort>]:<containerPort>[/tcp|udp]
-      --route-block=VALUE    Isolate all ports of specified protocol (TCP or UDP) by default
+      --route-add=VALUE      Add route mapping. Supported protocols: ip, pipe, tcp, udp
+      --route-block=VALUE    Block specified route or protocol. Supported protocols: ip, tcp, udp
       --startup-file=VALUE   Override the default startup file
       --startup-file-default=VALUE
                              Overrides the default startup file if the main image does not have one

--- a/reference/command_line/try.md
+++ b/reference/command_line/try.md
@@ -22,8 +22,8 @@ Usage: turbo try <options> <image> [<parameters>...]
       --network=VALUE        Run container in specified virtual network
       --no-stream            Force no streaming even when stream is available
       --pull                 Pulls base images from hub before running, if they exist
-      --route-add=VALUE      Add a TCP or UDP mapping, format: [<hostPort>]:<containerPort>[/tcp|udp]
-      --route-block=VALUE    Isolate all ports of specified protocol (TCP or UDP) by default
+      --route-add=VALUE      Add route mapping. Supported protocols: ip, pipe, tcp, udp
+      --route-block=VALUE    Block specified route or protocol. Supported protocols: ip, tcp, udp
       --startup-file=VALUE   Override the default startup file
       --trigger=VALUE        Execute named group of startup files
       --using=VALUE          Use specified images as a temporary dependency
@@ -135,15 +135,12 @@ dd73e48aec024a7b9e15d2cf6599394f
 All network operations (opening/closing ports, for example) are passed through to the local machine when running in the host network context. To remap container ports to other ports on the local machine, use the `--route-add` flag. This flag also works when running in a virtualized network environment (by specifying the `--network` flag). Specific protocols (tcp or udp) can be mapped by specifying a `/[protocol]` after the mapping. If no protocol is specified, tcp is assumed.
 
 ```
-# Map container tcp port 8080 to local port 80
-> turbo try --route-add=80:8080 <image>
+# Isolate all tcp services of a container
+> turbo try --route-block=tcp <image>
 
-# Map udp traffic on container port 8080 to local port 80
-> turbo try --route-add=80:8080/udp <image>
-
-# Map container tcp port 80 to random port on local machine
-# The random port can be later queried using the netstat command
-> turbo try --route-add=:80 <image>
+# Isolate all tcp and udp services, but allow container tcp port 3486
+# be bound to port 80 on local machine
+> turbo try --route-block=tcp,udp --route-add=tcp://3486:80 <image>
 ```
 
 The default policy of allowing containers to bind to any port on the local machine can be changed with the `--route-block` flag. It isolates all services bound to container ports on specified protocols (tcp or udp). They can only be opened using the `--route-add` flag.
@@ -154,7 +151,7 @@ The default policy of allowing containers to bind to any port on the local machi
 
 # Isolate all tcp and udp services, but allow container tcp port 3486
 # be bound to port 80 on local machine
-> turbo try --route-block=tcp,udp --route-add=80:3486 <image>
+> turbo try --route-block=tcp,udp --route-add=tcp://3486:80 <image>
 ```
 
 #### Adding Custom Name Resolution Entries


### PR DESCRIPTION
Using the changed syntax in the route-add flags