### PR TITLE
Example is inline with documentation, adding newer version last.

### DIFF
--- a/reference/command_line/new.md
+++ b/reference/command_line/new.md
@@ -62,7 +62,7 @@ Turbo `new` can be used to specify multiple images by separating each image with
 > turbo new apache/apache,mysql/mysql
 
 # Create a container with .NET 3 and 4
-> turbo new microsoft/dotnet:4.0.3,microsoft/dotnet:3.5.1
+> turbo new microsoft/dotnet:3.5.1,microsoft/dotnet:4.0.3
 ```
 
 To use images temporarily, without committing them to the final image, use the `--using` switch. This is handy for a tool like 7zip and Git that may only needed during the build process.

--- a/reference/command_line/run.md
+++ b/reference/command_line/run.md
@@ -60,7 +60,7 @@ Turbo `run` can be used to specify multiple images by separating each image with
 > turbo run apache/apache,mysql/mysql
 
 # Create a container with .NET 3 and 4
-> turbo run microsoft/dotnet:4.0.3,microsoft/dotnet:3.5.1
+> turbo run microsoft/dotnet:3.5.1,microsoft/dotnet:4.0.3
 ```
 
 To use images temporarily, without committing them to the final image, use the `--using` switch. This is handy for a tool like 7zip and Git that may only needed during the build process.

--- a/reference/command_line/try.md
+++ b/reference/command_line/try.md
@@ -44,7 +44,7 @@ Turbo `try` can be used to specify multiple images by separating each image with
 > turbo try apache/apache,mysql/mysql
 
 # Create a container with .NET 3 and 4
-> turbo try microsoft/dotnet:4.0.3,microsoft/dotnet:3.5.1
+> turbo try microsoft/dotnet:3.5.1,microsoft/dotnet:4.0.3
 ```
 
 Containers are started with the startup file specified in the last passed image. If a startup file is not set in the base image then `cmd.exe /k` is used.


### PR DESCRIPTION
Documentation says you should add a newer version of the same lib after. Example did the opposite. 

Example now as documentation states: turbo new image:v1, image:v2