### PR TITLE
Update ghost scenario for run changes

### DIFF
--- a/getting_started/walkthrough_-_node_and_ghost/walkthrough_ii.md
+++ b/getting_started/walkthrough_-_node_and_ghost/walkthrough_ii.md
@@ -157,15 +157,15 @@ However, with the help of port mapping, we can run multiple instances of the Gho
 
 ```
 # Create a container that maps port 8080 on the host to port 2368 on the container.
-C:\> turbo run -d --route-add=tcp://2368:8080 ghost:0.5.1
+C:\> turbo new -d --route-add=tcp://2368:8080 ghost:0.5.1
 8bc1c8a0774e452391d6be6255d9d13e
 
 # Create a container that maps port 8081 on the host to port 2368 on the container.
-C:\> turbo run -d --route-add=tcp://2368:8081 ghost:0.5.1
+C:\> turbo new -d --route-add=tcp://2368:8081 ghost:0.5.1
 8a524a9fd6a047778bc88f3169a90780
 
 # Create a container that maps port 8082 on the host to port 2368 on the container.
-C:\> turbo run -d --route-add=tcp://2368:8082 ghost:0.5.1
+C:\> turbo new -d --route-add=tcp://2368:8082 ghost:0.5.1
 cee869387b74474b89bafccb5b590884
 ```
 


### PR DESCRIPTION
turbo run identifies containers based on imagelist+name, so we need to use turbo new to prevent a 'cannot start container because it is already running' error.

question: should we leave the other 'turbo run' command in or should we update them to 'turbo new' to maintain consistency?